### PR TITLE
Fix: Removed comments that were breaking the code

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -21,8 +21,6 @@ import (
 	"github.com/zakkor/server/tools"
 )
 
-//go:embed dist-client/*
-//go:embed dist-client/**/*
 var staticFiles embed.FS
 
 var llamaPath = flag.String("llama", "", "Path to the llama.cpp directory. You only need this if you want to run local models using llama.cpp.")


### PR DESCRIPTION
The comments were causing a "no matching files found" error for the embed pattern. After removing the comments, the server builds successfully.